### PR TITLE
fix: SDP-11490: fix chart release upgrade

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -78,6 +78,25 @@ jobs:
           myobj:
             myproperty: override value
             examplejsonstring: '{"auths":{}}'
+    - name: upgrade chart release with changed values
+      uses: .
+      with:
+        release-name: example
+        chart-location: charts/example
+        dependency-build: 'true'
+        namespace: ${{ steps.createns.outputs.name }}
+        debug: 'true'
+        timeout: 1m
+        values: |
+          myobj:
+            myproperty: changed value
+            examplejsonstring: '{"auths":{}}'
+    - name: verify chart release was upgraded
+      uses: docker://alpine/k8s:1.27.3
+      run: |
+        set -eu
+        VAL="$(kubectl get cm example -n ${{ steps.createns.outputs.name }} -o jsonpath={.data.key})"
+        [ "$VAL" = 'changed value' ]
     - id: invalid-inline-values
       name: Try to install a helm chart with malformed inline values
       continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/charts/*/charts/

--- a/action.yml
+++ b/action.yml
@@ -94,12 +94,10 @@ runs:
             statusCheckDeadlineSeconds: 90
             helm:
               releases:
-              - name: WILL_BE_REPLACED_BELOW
-                valuesFiles:
+              - valuesFiles:
                 - /tmp/values.yaml
                 createNamespace: true
                 skipBuildDependencies: true
-                upgradeOnChange: false
         EOF
         yq -i '.
           | .deploy.helm.releases[0].name = env(RELEASE_NAME)
@@ -151,6 +149,7 @@ runs:
         else
           # Let skaffold deploy the chart to log details on failure
           cd /tmp/skaffold
+          skaffold config set collect-metrics false
           skaffold deploy
         fi
       env:

--- a/charts/example_with_dependency/Chart.lock
+++ b/charts/example_with_dependency/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: karpenter
-  repository: oci://public.ecr.aws/karpenter
-  version: v0.27.0
-digest: sha256:57fcfdcf6e2322f1047e09c9ab957190213d5dea5a5ee430f36abe9b9bea140a
-generated: "2023-07-04T18:50:09.818559474Z"
+- name: nginx
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 15.4.2
+digest: sha256:9305d044c1ff6da7e3a27544005c1b65d0a182c60beb8625026fb1fb43d9ac8e
+generated: "2023-11-17T23:59:33.134025466+01:00"

--- a/charts/example_with_dependency/Chart.yaml
+++ b/charts/example_with_dependency/Chart.yaml
@@ -5,6 +5,6 @@ type: application
 version: 0.0.0
 appVersion: "0.0.0"
 dependencies:
-- name: karpenter
-  version: "v0.27.0"
-  repository: "oci://public.ecr.aws/karpenter"
+- name: nginx
+  version: "15.4.2"
+  repository: "oci://registry-1.docker.io/bitnamicharts"


### PR DESCRIPTION
Since we’re using skaffold as a helm wrapper (to log more details on deployment failure), helm chart releases (installations) are not upgraded anymore but skaffold does nothing in that case but silently returns successfully.

Related skaffold issue: https://github.com/GoogleContainerTools/skaffold/issues/6113

This PR fixes chart release upgrades by making the generated skaffold.yaml not specify `upgradeOnChange: false`.
Also the PR adds a chart release upgrade test to the workflow.