### PR TITLE
CBP-8068  Digest generated from helm-install when using a local chart is different in jobs in the same workflow

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -266,6 +266,7 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
+            echo "test"
 
             # Save the chart artifact information
             payload="{

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -242,17 +242,13 @@ runs:
               # Handle non-OCI images
               if [ -f "$CHART_PATH" ] && [[ "$CHART_PATH" == *.tgz ]]; then
                 sha256_digest="sha256:$(sha256sum "$CHART_PATH" | awk '{print $1}')"
-                echo "sha256_digest is sha256_digest"
               else
-                # Calculate the sha256 digest of the chart sorted files content
-                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum)
-                echo "sha256_content is $sha256_content"
-                # Calculate the sha256 digest of the chart sorted files and directories names
-                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum)
-                echo "sha256_names is sha256_names"
-                # Calculate the sha256 digest of the two previous digests with prefix "sha256:"
-                sha256_digest="sha256:$(cat $sha256_content,$sha256_names | sha256sum | awk '{print $1}')"
-                echo "sha256_digest is sha256_digest"
+                # Calculate the sha256 digests of the chart sorted files content
+                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum | awk '{print $1}')
+                # Calculate the sha256 digests of the chart sorted files and directories names
+                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum | awk '{print $1}')
+                # Calculate the final sha256 digest of the two previous digests with prefix "sha256:"
+                sha256_digest="sha256:$(echo "$sha256_content $sha256_names" | sha256sum | awk '{print $1}')"
               fi
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -251,7 +251,7 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
-        
+              
               echo ""
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -251,6 +251,7 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
+              echo "test"
 
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -251,11 +251,12 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
-              
+        
               echo ""
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
+              tar -ztvf "$artifactPath"
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -240,32 +240,20 @@ runs:
               fi
             else
               # Handle non-OCI images
-              artifactPath=""
               if [ -f "$CHART_PATH" ] && [[ "$CHART_PATH" == *.tgz ]]; then
-                artifactPath="$CHART_PATH"
+                sha256_digest="sha256:$(sha256sum "$CHART_PATH" | awk '{print $1}')"
+                echo "sha256_digest is sha256_digest"
               else
-                if helm package $CHART_PATH --destination "$tmp_dir" > /dev/null 2>&1; then
-                  artifactPath=$(ls -Art "$tmp_dir"/*.tgz | tail -n 1)
-                fi
+                # Calculate the sha256 digest of the chart sorted files content
+                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum)
+                echo "sha256_content is $sha256_content"
+                # Calculate the sha256 digest of the chart sorted files and directories names
+                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum)
+                echo "sha256_names is sha256_names"
+                # Calculate the sha256 digest of the two previous digests with prefix "sha256:"
+                sha256_digest="sha256:$(cat $sha256_content,$sha256_names | sha256sum | awk '{print $1}')"
+                echo "sha256_digest is sha256_digest"
               fi
-              if [ -f "$artifactPath" ]; then
-                sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
-              fi
-              
-              echo ""
-              echo "sha256_digest is $sha256_digest"
-              echo "artifactPath is $artifactPath"
-              ls -lat "$artifactPath"
-              ls -lat "$CHART_PATH"
-              # tar tzvf "$artifactPath"
-              # ls -la /bin
-              # ls -la /usr/bin
-              # ls -la /usr/local/bin
-              echo "Chart.yaml: "
-              cat "$CHART_PATH"/Chart.yaml
-              echo "values.yaml: "
-              cat "$CHART_PATH"/values.yaml
-              echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -251,7 +251,13 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
-
+              
+              echo ""
+              echo "sha256_digest is $sha256_digest"
+              echo "artifactPath is $artifactPath"
+              ls -lat "$artifactPath"
+              echo ""
+              
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"
               helm show chart "$CHART_PATH" > "$chart_yaml"
@@ -266,11 +272,6 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
-            echo ""
-            echo "sha256_digest is $sha256_digest"
-            echo "artifactPath is $artifactPath"
-            ls -lat "$artifactPath"
-            echo ""
 
             # Save the chart artifact information
             payload="{

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -261,6 +261,10 @@ runs:
               # ls -la /bin
               # ls -la /usr/bin
               # ls -la /usr/local/bin
+              echo "Chart.yaml: "
+              cat "$CHART_PATH"/Chart.yaml
+              echo "values.yaml: "
+              cat "$CHART_PATH"/values.yaml
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -269,6 +269,7 @@ runs:
             echo ""
             echo "sha256_digest is $sha256_digest"
             echo "artifactPath is $artifactPath"
+            ls -lat "$artifactPath"
             echo ""
 
             # Save the chart artifact information

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -266,7 +266,10 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
-            echo "test"
+            echo ""
+            echo "sha256_digest is $sha256_digest"
+            echo "artifactPath is $artifactPath"
+            echo ""
 
             # Save the chart artifact information
             payload="{

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -257,9 +257,9 @@ runs:
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
               # tar tzvf "$artifactPath"
-              la -la /bin
-              la -la /usr/bin
-              la -la /usr/local/bin
+              ls -la /bin
+              ls -la /usr/bin
+              ls -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -256,7 +256,10 @@ runs:
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
-              tar -ztvf "$artifactPath"
+              # tar tzvf "$artifactPath"
+              la -la /bin
+              la -la /usr/bin
+              la -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -256,10 +256,11 @@ runs:
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
+              ls -lat "$CHART_PATH"
               # tar tzvf "$artifactPath"
-              ls -la /bin
-              ls -la /usr/bin
-              ls -la /usr/local/bin
+              # ls -la /bin
+              # ls -la /usr/bin
+              # ls -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -251,7 +251,6 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
-              echo "test"
 
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"

--- a/action.yml
+++ b/action.yml
@@ -266,6 +266,7 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
+            echo "test"
 
             # Save the chart artifact information
             payload="{

--- a/action.yml
+++ b/action.yml
@@ -242,17 +242,13 @@ runs:
               # Handle non-OCI images
               if [ -f "$CHART_PATH" ] && [[ "$CHART_PATH" == *.tgz ]]; then
                 sha256_digest="sha256:$(sha256sum "$CHART_PATH" | awk '{print $1}')"
-                echo "sha256_digest is sha256_digest"
               else
-                # Calculate the sha256 digest of the chart sorted files content
-                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum)
-                echo "sha256_content is $sha256_content"
-                # Calculate the sha256 digest of the chart sorted files and directories names
-                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum)
-                echo "sha256_names is sha256_names"
-                # Calculate the sha256 digest of the two previous digests with prefix "sha256:"
-                sha256_digest="sha256:$(cat $sha256_content,$sha256_names | sha256sum | awk '{print $1}')"
-                echo "sha256_digest is sha256_digest"
+                # Calculate the sha256 digests of the chart sorted files content
+                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum | awk '{print $1}')
+                # Calculate the sha256 digests of the chart sorted files and directories names
+                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum | awk '{print $1}')
+                # Calculate the final sha256 digest of the two previous digests with prefix "sha256:"
+                sha256_digest="sha256:$(echo "$sha256_content $sha256_names" | sha256sum | awk '{print $1}')"
               fi
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/action.yml
+++ b/action.yml
@@ -240,32 +240,20 @@ runs:
               fi
             else
               # Handle non-OCI images
-              artifactPath=""
               if [ -f "$CHART_PATH" ] && [[ "$CHART_PATH" == *.tgz ]]; then
-                artifactPath="$CHART_PATH"
+                sha256_digest="sha256:$(sha256sum "$CHART_PATH" | awk '{print $1}')"
+                echo "sha256_digest is sha256_digest"
               else
-                if helm package $CHART_PATH --destination "$tmp_dir" > /dev/null 2>&1; then
-                  artifactPath=$(ls -Art "$tmp_dir"/*.tgz | tail -n 1)
-                fi
+                # Calculate the sha256 digest of the chart sorted files content
+                sha256_content=$(find "$CHART_PATH" -type f -print0 | sort -z | xargs -0 sha256sum)
+                echo "sha256_content is $sha256_content"
+                # Calculate the sha256 digest of the chart sorted files and directories names
+                sha256_names=$(find "$CHART_PATH" \( -type f -o -type d \) -print0 | sort -z | xargs -0 | sha256sum)
+                echo "sha256_names is sha256_names"
+                # Calculate the sha256 digest of the two previous digests with prefix "sha256:"
+                sha256_digest="sha256:$(cat $sha256_content,$sha256_names | sha256sum | awk '{print $1}')"
+                echo "sha256_digest is sha256_digest"
               fi
-              if [ -f "$artifactPath" ]; then
-                sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
-              fi
-              
-              echo ""
-              echo "sha256_digest is $sha256_digest"
-              echo "artifactPath is $artifactPath"
-              ls -lat "$artifactPath"
-              ls -lat "$CHART_PATH"
-              # tar tzvf "$artifactPath"
-              # ls -la /bin
-              # ls -la /usr/bin
-              # ls -la /usr/local/bin
-              echo "Chart.yaml: "
-              cat "$CHART_PATH"/Chart.yaml
-              echo "values.yaml: "
-              cat "$CHART_PATH"/values.yaml
-              echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"

--- a/action.yml
+++ b/action.yml
@@ -251,7 +251,13 @@ runs:
               if [ -f "$artifactPath" ]; then
                 sha256_digest="sha256:$(sha256sum "$artifactPath" | awk '{print $1}')"
               fi
-
+              
+              echo ""
+              echo "sha256_digest is $sha256_digest"
+              echo "artifactPath is $artifactPath"
+              ls -lat "$artifactPath"
+              echo ""
+              
               # Extract chart information from the non-OCI chart (local directory or archive)
               chart_yaml="$tmp_dir/Chart.yaml"
               helm show chart "$CHART_PATH" > "$chart_yaml"
@@ -266,11 +272,6 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
-            echo ""
-            echo "sha256_digest is $sha256_digest"
-            echo "artifactPath is $artifactPath"
-            ls -lat "$artifactPath"
-            echo ""
 
             # Save the chart artifact information
             payload="{

--- a/action.yml
+++ b/action.yml
@@ -261,6 +261,10 @@ runs:
               # ls -la /bin
               # ls -la /usr/bin
               # ls -la /usr/local/bin
+              echo "Chart.yaml: "
+              cat "$CHART_PATH"/Chart.yaml
+              echo "values.yaml: "
+              cat "$CHART_PATH"/values.yaml
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/action.yml
+++ b/action.yml
@@ -269,6 +269,7 @@ runs:
             echo ""
             echo "sha256_digest is $sha256_digest"
             echo "artifactPath is $artifactPath"
+            ls -lat "$artifactPath"
             echo ""
 
             # Save the chart artifact information

--- a/action.yml
+++ b/action.yml
@@ -266,7 +266,10 @@ runs:
             rm -rf "$tmp_dir"
 
             echo "Saving artifact information for chart $CHART_LOCATION"
-            echo "test"
+            echo ""
+            echo "sha256_digest is $sha256_digest"
+            echo "artifactPath is $artifactPath"
+            echo ""
 
             # Save the chart artifact information
             payload="{

--- a/action.yml
+++ b/action.yml
@@ -257,9 +257,9 @@ runs:
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
               # tar tzvf "$artifactPath"
-              la -la /bin
-              la -la /usr/bin
-              la -la /usr/local/bin
+              ls -la /bin
+              ls -la /usr/bin
+              ls -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/action.yml
+++ b/action.yml
@@ -256,7 +256,10 @@ runs:
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
-              tar -ztvf "$artifactPath"
+              # tar tzvf "$artifactPath"
+              la -la /bin
+              la -la /usr/bin
+              la -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/action.yml
+++ b/action.yml
@@ -256,10 +256,11 @@ runs:
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
+              ls -lat "$CHART_PATH"
               # tar tzvf "$artifactPath"
-              ls -la /bin
-              ls -la /usr/bin
-              ls -la /usr/local/bin
+              # ls -la /bin
+              # ls -la /usr/bin
+              # ls -la /usr/local/bin
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)

--- a/action.yml
+++ b/action.yml
@@ -256,6 +256,7 @@ runs:
               echo "sha256_digest is $sha256_digest"
               echo "artifactPath is $artifactPath"
               ls -lat "$artifactPath"
+              tar -ztvf "$artifactPath"
               echo ""
               
               # Extract chart information from the non-OCI chart (local directory or archive)


### PR DESCRIPTION
Reimplemented digest generation without creation tar archive in the tmp folder.