### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/l7o7z1g8/services/registry-config:0.0.22 as registry-config
+FROM public.ecr.aws/l7o7z1g8/services/registry-config:0.0.25 as registry-config
 
 FROM alpine/helm:3.17.2
 


### PR DESCRIPTION
Bumped  registry-config to latest to address:
 CVE-2024-34155 - stdlib-go1.22.5(go)
 CVE-2025-22866 - stdlib-go1.22.5(go) 
 CVE-2024-45341 - stdlib-go1.22.5(go)
 CVE-2024-45336 - stdlib-go1.22.5(go)
 CVE-2024-34158 - stdlib-go1.22.5(go)