### PR TITLE
chore(CBP-18718): update helm base image to latest (3.18.6) and k8s t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/l7o7z1g8/services/registry-config:0.0.32 as registry-config
 
-FROM alpine/helm:3.18.3
+FROM alpine/helm:3.18.6
 
 RUN set -eux; \
     apk add --no-cache yq; \
@@ -14,7 +14,7 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/skaffold; \
 	skaffold version
 
-ARG K8S_VERSION=v1.33.2
+ARG K8S_VERSION=v1.33.4
 RUN set -eux; \
 	ARCH="`uname -m | sed 's!x86_64!amd64!; s!aarch64!arm64!'`"; \
 	wget -qO /usr/local/bin/kubectl https://dl.k8s.io/release/$K8S_VERSION/bin/linux/$ARCH/kubectl; \


### PR DESCRIPTION
…o latest 1.33.4

A better way to do the dependencies of skaffold and kubectl would be to download those in a separate phase and copy the required files into the final image.