### PR TITLE
CBP-47071: make the 'create-namespace' helm install input configurable, defaults to 'true'

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -9,6 +9,9 @@ inputs:
   namespace:
     description: 'Kubernetes namespace to install the chart in, created if missing'
     default: default
+  create-namespace:
+    description: 'Whether to create the namespace if it does not exist'
+    default: 'true'
   version:
     description: 'Version of the chart to be installed'
   # DEPRECATED: values-file is deprecated, use values-files instead
@@ -52,6 +55,10 @@ inputs:
       CloudBees registry configuration file containing the registries to use for loading images.
       By default it uses the file containing the registries configured under 'Integrations' in the CloudBees platform.
     default: ${{ cloudbees.registries }}
+outputs:
+  release-revision:
+    description: 'The helm release revision number after install/upgrade'
+    value: ${{ steps.helm-install.outputs.release-revision }}
 runs:
   using: composite
   steps:
@@ -126,7 +133,7 @@ runs:
               releases:
               - valuesFiles:
                 - /tmp/values.yaml
-                createNamespace: true
+                ${{ inputs.create-namespace == 'true' && 'createNamespace: true' || 'createNamespace: false' }}
                 skipBuildDependencies: true
                 upgradeOnChange: true
               flags:
@@ -207,11 +214,13 @@ runs:
             --create-namespace \
             --timeout "$TIMEOUT" \
             --dry-run
+          printf '' > $CLOUDBEES_OUTPUTS/release-revision
         else
           # Let skaffold deploy the chart to log details on failure
           cd /tmp/skaffold
           skaffold config set collect-metrics false
           skaffold deploy
+          printf %s "$(helm status "$RELEASE_NAME" -n "$HELM_NAMESPACE" -o yaml | yq '.version')" > $CLOUDBEES_OUTPUTS/release-revision
         fi
       env:
         CHART_LOCATION: ${{ inputs.chart-location }}

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -255,7 +255,56 @@ jobs:
         namespace: ${{ steps.createns.outputs.name }}
         timeout: 1m
         wait: 'false'
-    - name: test startup probe failure scenario 
+    - id: create-namespace-false-existing-ns
+      name: install a helm chart with create-namespace set to false into existing namespace
+      uses: ./.cloudbees/testing
+      with:
+        release-name: example-no-create-ns
+        chart-location: charts/example
+        namespace: ${{ steps.createns.outputs.name }}
+        create-namespace: 'false'
+        timeout: 2m
+    - name: verify create-namespace false into existing namespace produced a release revision
+      uses: docker://alpine/k8s:1.31.2
+      run: |
+        set -ux
+        [ -n "${REVISION}" ]
+      env:
+        REVISION: ${{ steps.create-namespace-false-existing-ns.outputs.release-revision }}
+    - id: create-namespace-true-new-ns
+      name: install a helm chart with create-namespace set to true into new namespace
+      uses: ./.cloudbees/testing
+      with:
+        release-name: example-create-ns
+        chart-location: charts/example
+        namespace: ${{ format('cn-{0}', cloudbees.scm.sha) }}
+        create-namespace: 'true'
+        timeout: 2m
+    - name: verify create-namespace true into new namespace produced a release revision
+      uses: docker://alpine/k8s:1.31.2
+      run: |
+        set -ux
+        [ -n "${REVISION}" ]
+      env:
+        REVISION: ${{ steps.create-namespace-true-new-ns.outputs.release-revision }}
+    - id: create-namespace-false-missing-ns
+      name: install a helm chart with create-namespace false into non-existent namespace
+      continue-on-error: true
+      uses: ./.cloudbees/testing
+      with:
+        release-name: example-no-ns
+        chart-location: charts/example
+        namespace: ${{ format('missing-{0}', cloudbees.scm.sha) }}
+        create-namespace: 'false'
+        timeout: 2m
+    - name: verify create-namespace false into missing namespace produced no release revision
+      uses: docker://alpine/k8s:1.31.2
+      run: |
+        set -ux
+        [ -z "${REVISION}" ]
+      env:
+        REVISION: ${{ steps.create-namespace-false-missing-ns.outputs.release-revision }}
+    - name: test startup probe failure scenario
       continue-on-error: true
       uses: ./.cloudbees/testing
       with:

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   namespace:
     description: 'Kubernetes namespace to install the chart in, created if missing'
     default: default
+  create-namespace:
+    description: 'Whether to create the namespace if it does not exist'
+    default: 'true'
   version:
     description: 'Version of the chart to be installed'
   # DEPRECATED: values-file is deprecated, use values-files instead
@@ -52,6 +55,10 @@ inputs:
       CloudBees registry configuration file containing the registries to use for loading images.
       By default it uses the file containing the registries configured under 'Integrations' in the CloudBees platform.
     default: ${{ cloudbees.registries }}
+outputs:
+  release-revision:
+    description: 'The helm release revision number after install/upgrade'
+    value: ${{ steps.helm-install.outputs.release-revision }}
 runs:
   using: composite
   steps:
@@ -126,7 +133,7 @@ runs:
               releases:
               - valuesFiles:
                 - /tmp/values.yaml
-                createNamespace: true
+                ${{ inputs.create-namespace == 'true' && 'createNamespace: true' || 'createNamespace: false' }}
                 skipBuildDependencies: true
                 upgradeOnChange: true
               flags:
@@ -207,11 +214,13 @@ runs:
             --create-namespace \
             --timeout "$TIMEOUT" \
             --dry-run
+          printf '' > $CLOUDBEES_OUTPUTS/release-revision
         else
           # Let skaffold deploy the chart to log details on failure
           cd /tmp/skaffold
           skaffold config set collect-metrics false
           skaffold deploy
+          printf %s "$(helm status "$RELEASE_NAME" -n "$HELM_NAMESPACE" -o yaml | yq '.version')" > $CLOUDBEES_OUTPUTS/release-revision
         fi
       env:
         CHART_LOCATION: ${{ inputs.chart-location }}


### PR DESCRIPTION
Add `create-namespace` input and `release-revision `output

**Summary**

  - Added a `create-namespace` input (default `true`) that controls whether Skaffold creates the target namespace if it does not exist. Previously this was hardcoded to true with no way to opt out.
  - Added a `release-revision` output that exposes the Helm release revision number after a successful install or upgrade. Returns an empty string for dry-run executions.
  - Added workflow tests covering three `create-namespace` scenarios: false into an existing namespace (positive — expects a revision), true into a new namespace (positive — expects a revision), and false into a missing namespace (negative — expects no revision).

**Test plan**

  - install a helm chart with `create-namespace` set to `false` into existing namespace — verifies release-revision is non-empty
  - install a helm chart with `create-namespace` set to `true` into new namespace — verifies release-revision is non-empty in a freshly created namespace
  - install a helm chart with `create-namespace` set to `false` into non-existent namespace — verifies the install fails gracefully and release-revision is empty
  - All existing install/upgrade tests continue to pass (backward-compatible: create-namespace defaults to true)

