### PR TITLE
[CBP-41198] bump skaffold to v2.22.0 (latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN set -eux; \
     apk upgrade --no-cache; \
     apk upgrade --no-cache pcre2
 
-ARG SKAFFOLD_VERSION=v2.18.2
+ARG SKAFFOLD_VERSION=v2.22.0
 
 RUN set -eux; \
 	ARCH="`uname -m | sed 's!x86_64!amd64!; s!aarch64!arm64!'`"; \


### PR DESCRIPTION
bump skaffold to latest version which is built with golang 1.26.4 to fix CVE-2026-27143 in /usr/local/bin/skaffold